### PR TITLE
Up28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ cache:
     - node_modules
 
 env:
-  - EMBER_TRY_SCENARIO=default
   - EMBER_TRY_SCENARIO=ember-1.13
+  - EMBER_TRY_SCENARIO=ember-lts-2.4
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -19,6 +19,17 @@ module.exports = {
       }
     },
     {
+      name: 'ember-lts-2.4',
+      bower: {
+        dependencies: {
+          'ember': '~2.4.0'
+        },
+        resolutions: {
+          'ember': '~2.4.0'
+        }
+      }
+    },
+    {
       name: 'ember-release',
       bower: {
         dependencies: {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,9 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
     // Add options here
+    vendorFiles: {
+      'ember-resolver.js': null
+    }
   });
 
   /*

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
-    "ember-resolver": "^2.0.3",
     "loader.js": "^4.0.1"
   },
   "keywords": [

--- a/tests/unit/container-debug-adapter-test.js
+++ b/tests/unit/container-debug-adapter-test.js
@@ -7,13 +7,13 @@ import ContainerDebugAdapterInitializer from 'dummy/initializers/container-debug
 let containerDebugAdapter, App;
 
 var modules = {};
-function def(module) {
-  modules[module] = {};
+function def(_module) {
+  modules[_module] = {};
 }
 
-function undef(module) {
-  if (module) {
-    delete modules[module];
+function undef(_module) {
+  if (_module) {
+    delete modules[_module];
   } else {
     modules = {};
   }


### PR DESCRIPTION
@btecu This PR fixes the container-debug-adapter test for that we can upgrade ember-cli in ember-resolver and keep the adapter.  CC @rwjblue

In order for this to work you'll have rebase your branch and remove the commit that removes the adapter. Can you also please remove the commit that I submitted before about package.json? I submitted that PR with the wrong github account. This PR includes another commit for the same purpose.

So please remove the following 2 commits from your branch with a rebase and then merge this one.

 - dcbde71 `Remove legacy `containerDebugAdapter`, which exists in `Ember` since 1.5`
 - 10df5ad `remove ember-resolver from package.json`